### PR TITLE
[#35] Use env var start

### DIFF
--- a/h-util-ui/Electron/config.ts
+++ b/h-util-ui/Electron/config.ts
@@ -1,3 +1,3 @@
-const FORCE_DEV = false;
+const FORCE_PROD = false;
 
-export const isDev = FORCE_DEV || process.env.APP_IS_DEV ? true : false;
+export const isDev = process.env.APP_IS_DEV && !FORCE_PROD ? true : false;

--- a/h-util-ui/package.json
+++ b/h-util-ui/package.json
@@ -14,7 +14,7 @@
     "electron:setup": "yarn",
     "setup": "yarn front:setup && yarn electron:setup",
     "serve:front": "cd client && yarn dev",
-    "serve:electron": "set ELECTRON_ENABLE_LOGGING=1 && set APP_IS_NIGHTLY=yes && set APP_IS_DEV=yes && yarn build && wait-on tcp:3000 && electron --inspect=9229 .",
+    "serve:electron": "set ELECTRON_ENABLE_LOGGING=1 && set APP_IS_NIGHTLY=yes && set APP_IS_DEV=yes && yarn build &&  wait-on tcp:3000 && APP_IS_DEV=yes electron --inspect=9229 .",
     "build:front": "cd client && yarn build",
     "electron:build": "yarn build",
     "electron:builder": "electron-builder",


### PR DESCRIPTION
The previous setup (using `set var=var`) is more optimized for Windows use. Changes it to have set, but also pass the variable in nix systems.

Resolves #35