### PR TITLE
[#104] Split module options into components

### DIFF
--- a/h-util-ui/client/src/components/EditPipeline/ModuleTypeDropdown.vue
+++ b/h-util-ui/client/src/components/EditPipeline/ModuleTypeDropdown.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import MenuRight from 'vue-material-design-icons/MenuRight.vue';
+import { ProcessingModuleType } from '@shared/common.types';
+
+interface Props {
+  handleModuleTypeSelect: (moduleType: ProcessingModuleType) => void;
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+  <q-menu>
+    <q-list style="min-width: 100px">
+      <q-item @click="handleModuleTypeSelect(ProcessingModuleType.subfolder)" clickable v-close-popup="true">
+        <q-item-section>Place in directory</q-item-section>
+      </q-item>
+
+      <q-separator />
+      <q-item @click="handleModuleTypeSelect(ProcessingModuleType.metadata)" clickable v-close-popup="true">
+        <q-item-section>Metadata tag</q-item-section>
+      </q-item>
+      <q-item @click="handleModuleTypeSelect(ProcessingModuleType.datePrefix)" clickable v-close-popup="true">
+        <q-item-section>Date prefix</q-item-section>
+      </q-item>
+      <q-separator />
+
+      <q-item @click="handleModuleTypeSelect(ProcessingModuleType.iterate)" clickable v-close-popup="true">
+        <q-item-section>Iterate</q-item-section>
+      </q-item>
+      <q-item @click="handleModuleTypeSelect(ProcessingModuleType.report)" clickable v-close-popup="true">
+        <q-item-section>Log results</q-item-section>
+      </q-item>
+      <q-separator />
+      <q-item clickable>
+        <q-item-section>Media compression</q-item-section>
+        <q-item-section side>
+          <MenuRight :size="20" />
+        </q-item-section>
+        <q-menu anchor="top end" self="top start">
+          <q-list>
+            <q-item @click="handleModuleTypeSelect(ProcessingModuleType.compressImage)" clickable v-close-popup="true">
+              <q-item-section>Compress image</q-item-section>
+            </q-item>
+            <q-item @click="handleModuleTypeSelect(ProcessingModuleType.compressVideo)" clickable v-close-popup="true">
+              <q-item-section>Compress video</q-item-section>
+            </q-item>
+          </q-list>
+        </q-menu>
+      </q-item>
+      <q-item clickable>
+        <q-item-section>Filtering</q-item-section>
+        <q-item-section side>
+          <MenuRight :size="20" />
+        </q-item-section>
+
+        <q-menu anchor="top end" self="top start">
+          <q-list>
+            <q-item @click="handleModuleTypeSelect(ProcessingModuleType.filter)" clickable v-close-popup="true">
+              <q-item-section>Filter file</q-item-section>
+            </q-item>
+            <q-item @click="handleModuleTypeSelect(ProcessingModuleType.ocr)" clickable v-close-popup="true">
+              <q-item-section>Search image for text</q-item-section>
+            </q-item>
+          </q-list>
+        </q-menu>
+      </q-item>
+    </q-list>
+  </q-menu>
+</template>

--- a/h-util-ui/client/src/components/EditPipeline/PipelineOptions/OptionsDirectory.vue
+++ b/h-util-ui/client/src/components/EditPipeline/PipelineOptions/OptionsDirectory.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { getIpcRenderer } from '@utils/helpers';
+import { PipelineOptionsProps } from './pipelineOptions.common';
+import { computed } from 'vue';
+
+const props = defineProps<PipelineOptionsProps>();
+
+const handleDirPrompt = async () => {
+  const ipcRenderer = getIpcRenderer();
+
+  if (!ipcRenderer) return;
+
+  const folder = await ipcRenderer.selectFolder();
+  props.handleOptionChange('value', folder)
+}
+
+const directoryDisplay = computed(() => String(props.currentOptions.value ?? '').length ? props.currentOptions.value : 'Select a directory')
+</script>
+
+<template>
+  <div class="select-directory" @click="handleDirPrompt">{{
+    directoryDisplay }}</div>
+</template>
+
+<style scoped>
+.select-directory {
+  cursor: pointer;
+}
+</style>

--- a/h-util-ui/client/src/components/EditPipeline/PipelineOptions/OptionsStandard.vue
+++ b/h-util-ui/client/src/components/EditPipeline/PipelineOptions/OptionsStandard.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { PipelineOptionsProps } from './pipelineOptions.common';
+import { OPTION_LABELS } from '@utils/constants';
+
+const props = defineProps<PipelineOptionsProps>();
+
+const handleModuleOptionUpdated = (event: Event) => {
+  const newValue = (event.target as HTMLInputElement).value;
+
+  props.handleOptionChange('value', newValue);
+}
+
+const optionLabel = computed(() => OPTION_LABELS[props.moduleType]);
+</script>
+
+<template>
+  <q-input v-if="optionLabel" type="text" v-model="currentOptions.value" @input="handleModuleOptionUpdated"
+    :label="optionLabel ?? ''" />
+</template>

--- a/h-util-ui/client/src/components/EditPipeline/PipelineOptions/pipelineOptions.common.ts
+++ b/h-util-ui/client/src/components/EditPipeline/PipelineOptions/pipelineOptions.common.ts
@@ -1,0 +1,7 @@
+import { ProcessingModule, ProcessingModuleType } from '@shared/common.types';
+
+export interface PipelineOptionsProps {
+    moduleType: ProcessingModuleType;
+    currentOptions: ProcessingModule['options'];
+    handleOptionChange: (flag: keyof ProcessingModule['options'], newValue: string) => void;
+}

--- a/h-util-ui/client/src/components/TaskList/TaskList.vue
+++ b/h-util-ui/client/src/components/TaskList/TaskList.vue
@@ -46,7 +46,7 @@ const sortedTaskList = computed(() => {
       No tasks at this moment
     </span>
     <div v-if="sortedTaskList.length > 0">
-      <div v-for="spawnedTask in sortedTaskList">
+      <div v-for="spawnedTask in sortedTaskList" :key="spawnedTask.id">
         <TaskListItem :task="spawnedTask" />
       </div>
     </div>

--- a/h-util-ui/client/src/components/TaskList/TaskListItem.vue
+++ b/h-util-ui/client/src/components/TaskList/TaskListItem.vue
@@ -6,7 +6,6 @@ interface Props {
 }
 
 defineProps<Props>();
-
 </script>
 
 <template>

--- a/h-util-ui/client/src/utils/constants.ts
+++ b/h-util-ui/client/src/utils/constants.ts
@@ -10,6 +10,8 @@ import FileDocument from 'vue-material-design-icons/FileDocumentArrowRight.vue';
 
 import { ProcessingModule, ProcessingModuleType } from './types';
 import { VueComponent } from './util.types';
+import OptionsStandard from 'src/components/EditPipeline/PipelineOptions/OptionsStandard.vue';
+import OptionsDirectory from 'src/components/EditPipeline/PipelineOptions/OptionsDirectory.vue';
 
 /** If an emoji representation of the modules are needed */
 export const MODULE_ICONS: Record<ProcessingModuleType, string> = {
@@ -52,6 +54,18 @@ export const OPTION_LABELS: Record<ProcessingModuleType, string | null> = {
     [ProcessingModuleType.filter]: 'Filename match',
     [ProcessingModuleType.ocr]: 'Search string (CSV supported)',
     [ProcessingModuleType.report]: 'Save directory',
+};
+
+export const getOptionsComponent = (moduleType: ProcessingModuleType) => {
+    switch (moduleType) {
+        case ProcessingModuleType.datePrefix:
+        case ProcessingModuleType.metadata:
+            return null;
+        case ProcessingModuleType.report:
+            return OptionsDirectory;
+        default:
+            return OptionsStandard;
+    }
 };
 
 /** Get a default starter module */


### PR DESCRIPTION
Split module form options into various components to allow more content flexibility.

Resolves #104