### PR TITLE
[#81] Implement rules system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
         "tastique",
         "tauri",
         "Tesseract",
+        "uncast",
         "uuidv4"
     ],
     "vetur.validation.template": false,

--- a/h-util-ui/common/rules.spec.ts
+++ b/h-util-ui/common/rules.spec.ts
@@ -1,0 +1,48 @@
+import { AttributeType, Operator, Rule } from './rules.types';
+import { evaluateRule } from './rules.utils';
+
+type RuleTestScenario<T extends string = string> = {
+    data: Partial<Record<T, string>>;
+    rule: Rule<T>;
+    result: boolean;
+};
+
+/** Literally just to enforce types, doesn't do anything so special */
+const createRuleTestScenario = <T extends string>(scenarios: RuleTestScenario<T>[]): RuleTestScenario<T>[] => scenarios;
+
+describe('le rules system', () => {
+    test.each(
+        createRuleTestScenario([
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.string,
+                    operator: Operator.eq,
+                    attribute: 'name',
+                    value: 'IMG0000.txt',
+                },
+                result: false,
+                data: {
+                    name: 'string',
+                },
+            },
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.string,
+                    operator: Operator.eq,
+                    attribute: 'name',
+                    value: 'homework.mp4',
+                },
+                result: true,
+                data: {
+                    name: 'homework.mp4',
+                },
+            },
+        ]),
+    )('Simple string matches', (scenario) => {
+        const result = evaluateRule(scenario.rule, scenario.data);
+
+        expect(result).toEqual(scenario.result);
+    });
+});

--- a/h-util-ui/common/rules.spec.ts
+++ b/h-util-ui/common/rules.spec.ts
@@ -169,4 +169,114 @@ describe('le rules system', () => {
 
         expect(result).toEqual(scenario.result);
     });
+
+    test.each(
+        createRuleTestScenario([
+            {
+                rule: {
+                    type: 'AND',
+                    rules: [
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'name',
+                            value: 'IMG0000.txt',
+                        },
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'name',
+                            value: 'IMG0001.txt',
+                        },
+                    ],
+                },
+                result: false,
+                data: {
+                    name: 'IMG0000.txt',
+                },
+            },
+            {
+                rule: {
+                    type: 'AND',
+                    rules: [
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'name',
+                            value: 'IMG0000.txt',
+                        },
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'author',
+                            value: 'Nero',
+                        },
+                    ],
+                },
+                result: true,
+                data: {
+                    name: 'IMG0000.txt',
+                    author: 'Nero',
+                },
+            },
+            {
+                rule: {
+                    type: 'OR',
+                    rules: [
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'name',
+                            value: 'IMG0000.txt',
+                        },
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'name',
+                            value: 'IMG0001.txt',
+                        },
+                    ],
+                },
+                result: true,
+                data: {
+                    name: 'IMG0000.txt',
+                },
+            },
+            {
+                rule: {
+                    type: 'OR',
+                    rules: [
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'name',
+                            value: 'IMG0000.txt',
+                        },
+                        {
+                            type: 'basic',
+                            attributeType: AttributeType.string,
+                            operator: Operator.eq,
+                            attribute: 'name',
+                            value: 'IMG0001.txt',
+                        },
+                    ],
+                },
+                result: false,
+                data: {
+                    name: 'IMG0003.txt',
+                },
+            },
+        ]),
+    )('AND/OR', (scenario) => {
+        const result = evaluateRule(scenario.rule, scenario.data);
+
+        expect(result).toEqual(scenario.result);
+    });
 });

--- a/h-util-ui/common/rules.spec.ts
+++ b/h-util-ui/common/rules.spec.ts
@@ -8,7 +8,9 @@ type RuleTestScenario<T extends string = string> = {
 };
 
 /** Literally just to enforce types, doesn't do anything so special */
-const createRuleTestScenario = <T extends string>(scenarios: RuleTestScenario<T>[]): RuleTestScenario<T>[] => scenarios;
+const createRuleTestScenario = <T extends string>(scenarios: RuleTestScenario<T>[]): RuleTestScenario<T>[] => {
+    return scenarios;
+};
 
 describe('le rules system', () => {
     test.each(
@@ -39,8 +41,130 @@ describe('le rules system', () => {
                     name: 'homework.mp4',
                 },
             },
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.string,
+                    operator: Operator.ne,
+                    attribute: 'name',
+                    value: 'nero.png',
+                },
+                data: {
+                    name: 'nero.png',
+                },
+                result: false,
+            },
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.string,
+                    operator: Operator.ne,
+                    attribute: 'name',
+                    value: 'nero.png',
+                },
+                data: {
+                    name: 'ishtar.png',
+                },
+                result: true,
+            },
         ]),
     )('Simple string matches', (scenario) => {
+        const result = evaluateRule(scenario.rule, scenario.data);
+
+        expect(result).toEqual(scenario.result);
+    });
+
+    test.each(
+        createRuleTestScenario([
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.number,
+                    operator: Operator.lt,
+                    attribute: 'fileSize',
+                    value: '2000',
+                },
+                result: true,
+                data: {
+                    fileSize: '1000',
+                },
+            },
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.number,
+                    operator: Operator.lt,
+                    attribute: 'fileSize',
+                    value: '500',
+                },
+                result: false,
+                data: {
+                    fileSize: '1000',
+                },
+            },
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.number,
+                    operator: Operator.gt,
+                    attribute: 'fileSize',
+                    value: '500',
+                },
+                result: true,
+                data: {
+                    fileSize: '1000',
+                },
+            },
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.number,
+                    operator: Operator.gt,
+                    attribute: 'fileSize',
+                    value: '2000',
+                },
+                result: false,
+                data: {
+                    fileSize: '1000',
+                },
+            },
+        ]),
+    )('Number matches', (scenario) => {
+        const result = evaluateRule(scenario.rule, scenario.data);
+
+        expect(result).toEqual(scenario.result);
+    });
+
+    test.each(
+        createRuleTestScenario([
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.date,
+                    operator: Operator.lt,
+                    attribute: 'created',
+                    value: '2024-04-01',
+                },
+                result: false,
+                data: {
+                    created: '2024-05-01',
+                },
+            },
+            {
+                rule: {
+                    type: 'basic',
+                    attributeType: AttributeType.date,
+                    operator: Operator.lt,
+                    attribute: 'created',
+                    value: '2024-06-01',
+                },
+                result: true,
+                data: {
+                    created: '2024-05-01',
+                },
+            },
+        ]),
+    )('Date rules', (scenario) => {
         const result = evaluateRule(scenario.rule, scenario.data);
 
         expect(result).toEqual(scenario.result);

--- a/h-util-ui/common/rules.types.ts
+++ b/h-util-ui/common/rules.types.ts
@@ -1,0 +1,38 @@
+export enum Operator {
+    eq = '=',
+    gt = '>',
+    lt = '<',
+    gte = '>=',
+    lte = '<=',
+    ne = '!=',
+    contains = 'contains',
+    notContains = 'does not contain',
+}
+
+export enum AttributeType {
+    string = 'string',
+    date = 'date',
+    number = 'number',
+    boolean = 'boolean',
+}
+
+export interface BasicRule<T extends string = string> {
+    type: 'basic';
+    attribute: T;
+    attributeType: AttributeType;
+    operator: Operator;
+    value: string;
+}
+
+export interface LogicalGroup<T extends string = string> {
+    type: 'AND' | 'OR';
+    rules: Rule<T>[];
+}
+
+export type Rule<T extends string = string> = BasicRule<T> | LogicalGroup<T>;
+
+export interface RuleSet {
+    name?: string;
+    description?: string;
+    root: Rule;
+}

--- a/h-util-ui/common/rules.utils.ts
+++ b/h-util-ui/common/rules.utils.ts
@@ -1,4 +1,4 @@
-import { BasicRule, Rule } from './rules.types';
+import { AttributeType, BasicRule, Rule } from './rules.types';
 
 export const evaluateRule = (rule: Rule, data: Record<string, string>): boolean => {
     if (rule.type === 'basic') return evaluateBasicRule(rule, data);
@@ -16,24 +16,48 @@ export function evaluateBasicRule<T extends string = string>(
     rule: BasicRule<T>,
     data: Record<string, string>,
 ): boolean {
-    const value = data[rule.attribute];
-    switch (rule.operator) {
-        case '=':
-            return value === rule.value;
-        case '>':
-            return value > rule.value;
-        case '<':
-            return value < rule.value;
-        case '>=':
-            return value >= rule.value;
-        case '<=':
-            return value <= rule.value;
-        case '!=':
-            return value !== rule.value;
-        case 'contains':
-            return value.includes(rule.value);
-        // Add more operators as needed
-        default:
-            return false;
+    try {
+        const uncastValue = data[rule.attribute];
+
+        if (!uncastValue && !!rule.value) return false;
+
+        const attrType = rule.attributeType;
+
+        const value =
+            attrType === AttributeType.number
+                ? +uncastValue
+                : attrType === AttributeType.date
+                  ? new Date(uncastValue)
+                  : uncastValue;
+        const castRuleValue =
+            attrType === AttributeType.number
+                ? +rule.value
+                : attrType === AttributeType.date
+                  ? new Date(rule.value)
+                  : rule.value;
+
+        switch (rule.operator) {
+            case '=':
+                return value === castRuleValue;
+            case '>':
+                return value > castRuleValue;
+            case '<':
+                return value < castRuleValue;
+            case '>=':
+                return value >= castRuleValue;
+            case '<=':
+                return value <= castRuleValue;
+            case '!=':
+                return value !== castRuleValue;
+            case 'contains':
+                if (typeof value !== 'string') return false;
+
+                return value.includes(rule.value);
+            // Add more operators as needed
+            default:
+                return false;
+        }
+    } catch {
+        return false;
     }
 }

--- a/h-util-ui/common/rules.utils.ts
+++ b/h-util-ui/common/rules.utils.ts
@@ -1,0 +1,39 @@
+import { BasicRule, Rule } from './rules.types';
+
+export const evaluateRule = (rule: Rule, data: Record<string, string>): boolean => {
+    if (rule.type === 'basic') return evaluateBasicRule(rule, data);
+
+    if (rule.type === 'AND') {
+        return rule.rules.every((subRule) => evaluateRule(subRule, data));
+    } else if (rule.type === 'OR') {
+        return rule.rules.some((subRule) => evaluateRule(subRule, data));
+    }
+
+    return false;
+};
+
+export function evaluateBasicRule<T extends string = string>(
+    rule: BasicRule<T>,
+    data: Record<string, string>,
+): boolean {
+    const value = data[rule.attribute];
+    switch (rule.operator) {
+        case '=':
+            return value === rule.value;
+        case '>':
+            return value > rule.value;
+        case '<':
+            return value < rule.value;
+        case '>=':
+            return value >= rule.value;
+        case '<=':
+            return value <= rule.value;
+        case '!=':
+            return value !== rule.value;
+        case 'contains':
+            return value.includes(rule.value);
+        // Add more operators as needed
+        default:
+            return false;
+    }
+}

--- a/h-util-ui/jest.config.js
+++ b/h-util-ui/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    roots: ['<rootDir>'],
+    testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/h-util-ui/package.json
+++ b/h-util-ui/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "scripts": {
     "build": "tsc && yarn build:front",
+    "test": "jest",
     "watch": "nodemon --exec yarn serve:electron",
     "start": "yarn nightly:rename && concurrently --names 'CLIENT-KUN,PACKARINO' --prefix-colors 'red,yellow' -k \"yarn serve:front\" \"yarn watch\"",
     "front:setup": "cd client && yarn",
@@ -72,7 +73,7 @@
   "type": "commonjs",
   "build": {
     "appId": "com.official-h-util-ui.app",
-    "productName": "H-Util UI",
+    "productName": "H-Util UI Nightly",
     "copyright": "Copyright © TdM",
     "publish": [
       {


### PR DESCRIPTION
Scaffolds some typings and helpers for a rules system, which allows for a handful of operators, expected data types and adds tests to ensure the helpers help the help.

<img width="320" alt="Screen Shot 2024-08-25 at 4 28 56 PM" src="https://github.com/user-attachments/assets/41e6fdd6-732e-4cf9-8597-eed6046a2900">

Resolves #81