### PR TITLE
[#76] Add color support for pipelines

### DIFF
--- a/h-util-ui/Electron/preload.ts
+++ b/h-util-ui/Electron/preload.ts
@@ -1,4 +1,3 @@
-import { FilterTestRequest } from '@shared/common.types';
 import { contextBridge, ipcRenderer } from 'electron/renderer';
 
 contextBridge.exposeInMainWorld('browserWindow', {

--- a/h-util-ui/client/src/App.vue
+++ b/h-util-ui/client/src/App.vue
@@ -6,12 +6,13 @@ import EditPipeline from './components/EditPipeline/EditPipeline.vue'
 import { VueComponent } from './utils/util.types'
 import { addErrorListeners, getIpcRenderer, loadUserData, sendMessageToMain } from './utils/helpers'
 import store from './utils/store'
+import { PageViews } from '@utils/types'
 
 const $q = useQuasar();
 
-const routes: Record<string, VueComponent> = {
-  '/': HomePage,
-  '/new': EditPipeline
+const routes: Record<PageViews, VueComponent> = {
+  [PageViews.Home]: HomePage,
+  [PageViews.Edit]: EditPipeline
 }
 const currentPath = ref(window.location.hash)
 

--- a/h-util-ui/client/src/components/HomePage.vue
+++ b/h-util-ui/client/src/components/HomePage.vue
@@ -5,11 +5,12 @@ import PlusBox from 'vue-material-design-icons/PlusBox.vue'
 import Information from 'vue-material-design-icons/Information.vue'
 import { useQuasar } from 'quasar'
 import AboutModal from './About/AboutModal.vue';
+import { navigateTo, PageViews } from '@utils/helpers';
 
 /* Auto dark for now */
 useQuasar().dark.set(true);
 
-const handleNewPipeline = () => window.location.href = '#/new';
+const handleNewPipeline = () => navigateTo(PageViews.Edit);
 </script>
 
 <template>
@@ -19,7 +20,6 @@ const handleNewPipeline = () => window.location.href = '#/new';
       <AboutModal :open-button="Information" />
       <PlusBox class="icon-button create-button" @click="handleNewPipeline" title="Create a new pipeline" />
     </nav>
-
   </section>
 
   <section class="main-content">

--- a/h-util-ui/client/src/components/about/AboutModal.vue
+++ b/h-util-ui/client/src/components/about/AboutModal.vue
@@ -17,7 +17,6 @@ const tab = ref(Tabs.about);
 const about = ref(false);
 const stats = ref<StatsStorage | null>(null);
 
-// Define props using the defineProps function
 defineProps<{
   openButton: any;
   openButtonProps?: Record<string, any>;

--- a/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
+++ b/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
@@ -2,6 +2,7 @@
 import { computed, ref, onBeforeMount } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
 import PlusBox from 'vue-material-design-icons/PlusBox.vue'
+import Palette from 'vue-material-design-icons/Palette.vue'
 import cloneDeep from 'lodash/cloneDeep';
 
 import { PageViews, ProcessingModule } from '@utils/types';
@@ -16,6 +17,7 @@ const pipelineModules = ref<ProcessingModule[]>([
 ]);
 
 const pipelineName = ref(`New pipeline ${new Date().toISOString()}`);
+const pipelineColor = ref<string>();
 const pipelineRanking = ref(DEFAULT_RANKING);
 
 onBeforeMount(() => {
@@ -24,6 +26,7 @@ onBeforeMount(() => {
   if (!selected) return;
   pipelineModules.value = cloneDeep(selected.processingModules);
   pipelineName.value = selected.name;
+  pipelineColor.value = selected.color;
   pipelineRanking.value = selected.manualRanking ?? DEFAULT_RANKING;
 })
 
@@ -49,6 +52,7 @@ const handleSavePipeline = () => {
     id: store.state.selectedPipeline?.id ?? uuidv4(),
     name: pipelineName.value,
     manualRanking: pipelineRanking.value,
+    color: pipelineColor.value,
     processingModules: pipelineModules.value
   })
 
@@ -85,6 +89,16 @@ const header = computed(() => !!store.state.selectedPipeline ? 'Edit pipeline' :
         @input="handlePipelineNameUpdated" />
       <q-input type="number" class="number-input input-field" label="Pipeline rank" v-model="pipelineRanking"
         @input="handlePipelineRankingUpdated" />
+      <q-input v-model="pipelineColor" :rules="['anyColor']" label="Display color" class="color-input">
+        <template v-slot:append>
+          <button class="button-with-icon-child">
+            <Palette class="icon-button cursor-pointer" :style="pipelineColor ? { color: pipelineColor } : undefined" />
+            <q-popup-proxy cover transition-show="scale" transition-hide="scale">
+              <q-color no-footer v-model="pipelineColor" />
+            </q-popup-proxy>
+          </button>
+        </template>
+      </q-input>
     </section>
 
     <q-card-section class="modules-container" v-for="(pipelineModule, index) in pipelineModules">
@@ -160,5 +174,10 @@ const header = computed(() => !!store.state.selectedPipeline ? 'Edit pipeline' :
   justify-content: center;
   display: flex;
   gap: 5px;
+}
+
+.color-input button {
+  margin: 0;
+  padding: 1em 0 0;
 }
 </style>

--- a/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
+++ b/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
@@ -89,7 +89,8 @@ const header = computed(() => !!store.state.selectedPipeline ? 'Edit pipeline' :
         @input="handlePipelineNameUpdated" />
       <q-input type="number" class="number-input input-field" label="Pipeline rank" v-model="pipelineRanking"
         @input="handlePipelineRankingUpdated" />
-      <q-input v-model="pipelineColor" :rules="['anyColor']" label="Display color" class="color-input">
+      <q-input v-model="pipelineColor" :rules="pipelineColor === '' ? [] : ['anyColor']" label="Display color"
+        class="color-input" no-error-icon>
         <template v-slot:append>
           <button class="button-with-icon-child">
             <Palette class="icon-button cursor-pointer" :style="pipelineColor ? { color: pipelineColor } : undefined" />
@@ -97,6 +98,9 @@ const header = computed(() => !!store.state.selectedPipeline ? 'Edit pipeline' :
               <q-color no-footer v-model="pipelineColor" />
             </q-popup-proxy>
           </button>
+        </template>
+        <template v-slot:error>
+          Not a valid color
         </template>
       </q-input>
     </section>

--- a/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
+++ b/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
@@ -4,10 +4,11 @@ import { v4 as uuidv4 } from 'uuid';
 import PlusBox from 'vue-material-design-icons/PlusBox.vue'
 import cloneDeep from 'lodash/cloneDeep';
 
-import { ProcessingModule } from '@utils/types';
+import { PageViews, ProcessingModule } from '@utils/types';
 import store from '@utils/store';
 import { DEFAULT_RANKING, getDefaultModule } from '@utils/constants';
 import EditPipelineModule from './EditPipelineModule.vue';
+import { navigateTo } from '@utils/helpers';
 
 /** Replace with prop if any. */
 const pipelineModules = ref<ProcessingModule[]>([
@@ -56,7 +57,7 @@ const handleSavePipeline = () => {
 
 const returnHome = () => {
   store.setSelectedPipeline(null);
-  window.location.href = '#/';
+  navigateTo(PageViews.Home);
 }
 
 const handlePipelineNameUpdated = (event: Event) => {

--- a/h-util-ui/client/src/components/pipelines/PipelineItem.vue
+++ b/h-util-ui/client/src/components/pipelines/PipelineItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, CSSProperties, ref } from 'vue';
 import { FileUploadOptions, useDropzone } from "vue3-dropzone";
 import Menu from 'vue-material-design-icons/DotsVertical.vue'
 
@@ -62,15 +62,14 @@ const onDrop: FileUploadOptions['onDrop'] = (acceptFiles: ElectronFile[], _rejec
 const cardStyle = computed(() => props.pipelineItem.color ? {
   boxShadow: `inset 0 0 10px 5px ${props.pipelineItem.color}`, /* Blur effect with a shadow */
   boxSizing: 'border-box'
-} : undefined)
+} satisfies CSSProperties : undefined)
 
 const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 </script>
 
 <template>
-  <q-card :class="{ 'pipeline-drop': isDragActive, 'pipeline-card': true, 'has-color': !!pipelineItem.color }"
-    :style="cardStyle">
-    <div v-bind="getRootProps()" class="cursor-pointer">
+  <q-card :class="{ 'pipeline-drop': isDragActive, 'pipeline-card': true, 'has-color': !!pipelineItem.color }">
+    <div v-bind="getRootProps()" class="cursor-pointer" :style="cardStyle">
       <div class="pipeline-item">
         {{ pipelineItem.name }}
       </div>

--- a/h-util-ui/client/src/components/pipelines/PipelineItem.vue
+++ b/h-util-ui/client/src/components/pipelines/PipelineItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { FileUploadOptions, useDropzone } from "vue3-dropzone";
 import Menu from 'vue-material-design-icons/DotsVertical.vue'
 
@@ -48,17 +48,28 @@ const onDrop: FileUploadOptions['onDrop'] = (acceptFiles: ElectronFile[], _rejec
       pipeline: props.pipelineItem
     }
 
+    /**
+     * Not a network request so not dealing with compressing the payload or using an id only
+     * There may be cost in serializing the pipeline but either seems trivial at this point but
+     * may improve in the future
+     */
     ipcRenderer?.send(IpcMessageType.runPipeline, [JSON.stringify(payload)])
   } else {
     sendMessageToMain('No files detected')
   }
 }
 
+const cardStyle = computed(() => props.pipelineItem.color ? {
+  boxShadow: `inset 0 0 10px 5px ${props.pipelineItem.color}`, /* Blur effect with a shadow */
+  boxSizing: 'border-box'
+} : undefined)
+
 const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 </script>
 
 <template>
-  <q-card :class="{ 'pipeline-drop': isDragActive, 'pipeline-card': true }">
+  <q-card :class="{ 'pipeline-drop': isDragActive, 'pipeline-card': true, 'has-color': !!pipelineItem.color }"
+    :style="cardStyle">
     <div v-bind="getRootProps()" class="cursor-pointer">
       <div class="pipeline-item">
         {{ pipelineItem.name }}
@@ -99,6 +110,12 @@ const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 </template>
 
 <style scoped>
+.has-color {
+  /* Border size fixed, but color is dynamic */
+  /* border: 5px solid transparent; */
+  box-sizing: border-box;
+}
+
 .pipeline-item {
   padding: 1em;
   font-weight: 500;

--- a/h-util-ui/client/src/components/pipelines/PipelineItem.vue
+++ b/h-util-ui/client/src/components/pipelines/PipelineItem.vue
@@ -5,12 +5,15 @@ import Menu from 'vue-material-design-icons/DotsVertical.vue'
 
 import store from '@utils/store';
 import { IpcMessageType } from '@shared/common.constants';
-import { Pipeline } from '@utils/types';
-import { getIpcRenderer, sendMessageToMain } from '@utils/helpers';
+import { PageViews, Pipeline } from '@utils/types';
+import { getIpcRenderer, navigateTo, sendMessageToMain } from '@utils/helpers';
 import { MODULE_MATERIAL_ICONS } from '@utils/constants';
 import DeleteConfirmModal from '../common/DeleteConfirmModal.vue';
 
 interface Props { pipelineItem: Pipeline }
+
+/** Electron supplements file path */
+type ElectronFile = File & { path: string };
 
 const props = defineProps<Props>()
 const ipcRenderer = getIpcRenderer();
@@ -22,7 +25,7 @@ const deletePipeline = () =>
 const selectPipeline = () => {
   store.setSelectedPipeline(props.pipelineItem)
 
-  window.location.href = '#/new';
+  navigateTo(PageViews.Edit);
 }
 
 const duplicatePipeline = () => {
@@ -34,14 +37,14 @@ const duplicatePipeline = () => {
 
   setTimeout(() => {
     store.setSelectedPipeline(created);
-    window.location.href = '#/new';
+    navigateTo(PageViews.Edit);
   }, 1000);
 }
 
-const onDrop: FileUploadOptions['onDrop'] = (acceptFiles: File[], _rejectReasons) => {
+const onDrop: FileUploadOptions['onDrop'] = (acceptFiles: ElectronFile[], _rejectReasons) => {
   if (acceptFiles.length) {
     const payload = {
-      filePaths: acceptFiles.map(f => (f as any).path),
+      filePaths: acceptFiles.map(f => f.path),
       pipeline: props.pipelineItem
     }
 

--- a/h-util-ui/client/src/utils/helpers.ts
+++ b/h-util-ui/client/src/utils/helpers.ts
@@ -1,6 +1,13 @@
 import { IpcMessageType } from '@shared/common.constants';
 import { StatsStorage, Storage } from '@shared/common.types';
 import { VueStore } from './store';
+import { PageViews } from './types';
+
+export { PageViews } from './types';
+
+export const navigateTo = (path: PageViews) => {
+    window.location.href = `#${path}`;
+};
 
 /**
  * Sometimes structuredClone throws an error, catch and retry with caveman method

--- a/h-util-ui/client/src/utils/types.ts
+++ b/h-util-ui/client/src/utils/types.ts
@@ -1,3 +1,8 @@
 export type { ProcessingModule, Pipeline, TaskQueue, SpawnedTask } from '../../../common/common.types';
 
 export { ProcessingModuleType } from '../../../common/common.types';
+
+export enum PageViews {
+    Home = '/',
+    Edit = '/new',
+}

--- a/h-util-ui/common/common.types.ts
+++ b/h-util-ui/common/common.types.ts
@@ -28,8 +28,11 @@ export type Pipeline = {
     created?: string;
     modified?: string;
     manualRanking?: number;
-    timesRan?: number;
     processingModules: ProcessingModule[];
+    /** Used for the card display */
+    color?: string;
+    /** Supplemented on load. todo: take out of this type */
+    timesRan?: number;
 };
 
 export type Storage = {


### PR DESCRIPTION
Simple solution for pipeline visual recognition - adds color border to pipeline card.

<img width="899" alt="Screen Shot 2024-09-08 at 2 23 25 PM" src="https://github.com/user-attachments/assets/b9a08424-505e-424f-a7cb-da077f8c5cec">
<img width="562" alt="Screen Shot 2024-09-08 at 2 25 28 PM" src="https://github.com/user-attachments/assets/f7ad154a-bea2-4e2c-9378-379873010609">

Resolves #76 