### PR TITLE
[#136] Provide pipeline visibility to nested components

### DIFF
--- a/h-util-ui/Electron/operations/modules/runPipeline.handler.ts
+++ b/h-util-ui/Electron/operations/modules/runPipeline.handler.ts
@@ -3,6 +3,8 @@ import { Storage } from '@shared/common.types';
 import { ProcessingError } from '@util/errors';
 import pipelineCache from '@util/cache';
 import { runPipelineForFiles } from '../handler';
+import { addEventLogForReport } from '../handler.helpers';
+import { splitFileNameFromPath } from '@common/fileops';
 
 type StoredPipelines = {
     pipelines?: Storage['pipelines'];
@@ -23,6 +25,10 @@ const runPipelineHandler: ModuleHandler<{}, StoredPipelines> = {
         const targetPipeline = dataStore.pipelines[opts.clientOptions.value];
 
         if (!targetPipeline) throw new ProcessingError('Target pipeline not found');
+
+        const { fileName } = splitFileNameFromPath(fileWithMeta.filePath);
+
+        addEventLogForReport(opts, fileName, 'pipeline', targetPipeline.name);
 
         await runPipelineForFiles({
             pipeline: targetPipeline,

--- a/h-util-ui/Electron/util/types.ts
+++ b/h-util-ui/Electron/util/types.ts
@@ -1,6 +1,7 @@
 import { ActionModule } from '@shared/common.types';
 
 export type CommonContext = {
+    /** Providing this enables the event recorder */
     eventLog?: string[];
     pipelineName?: string;
     pipelineId?: string;

--- a/h-util-ui/client/src/components/EditPipeline/ModuleTypeDropdown.vue
+++ b/h-util-ui/client/src/components/EditPipeline/ModuleTypeDropdown.vue
@@ -21,34 +21,26 @@ const menuItems: MenuItem[] = [
   },
   {
     type: 'item',
-    label: 'Metadata tag',
-    onClick: handleModuleTypeSelect(ProcessingModuleType.metadata)
-  },
-  {
-    type: 'item',
-    label: 'Date prefix',
-    onClick: handleModuleTypeSelect(ProcessingModuleType.datePrefix)
-  },
-  {
-    type: 'item',
     label: 'Dynamic renaming',
     onClick: handleModuleTypeSelect(ProcessingModuleType.dynamicRename)
   },
   { type: 'separator' },
   {
     type: 'item',
-    label: 'Iterate',
-    onClick: handleModuleTypeSelect(ProcessingModuleType.iterate)
-  },
-  {
-    type: 'item',
     label: 'Log results',
     onClick: handleModuleTypeSelect(ProcessingModuleType.report)
   },
+
   {
-    type: 'item',
-    label: 'Direct to pipeline',
-    onClick: handleModuleTypeSelect(ProcessingModuleType.runPipeline)
+    type: 'group',
+    label: 'Flow control',
+    items: [
+      {
+        type: 'item',
+        label: 'Direct to pipeline',
+        onClick: handleModuleTypeSelect(ProcessingModuleType.runPipeline)
+      },
+    ]
   },
   {
     type: 'group',
@@ -64,6 +56,11 @@ const menuItems: MenuItem[] = [
         label: 'Compress video',
         onClick: handleModuleTypeSelect(ProcessingModuleType.compressVideo)
       },
+      {
+        type: 'item',
+        label: 'Metadata tag',
+        onClick: handleModuleTypeSelect(ProcessingModuleType.metadata)
+      },
     ]
   },
   {
@@ -77,13 +74,29 @@ const menuItems: MenuItem[] = [
       },
       {
         type: 'item',
-        label: 'Filter file',
+        label: 'Search image for text',
+        onClick: handleModuleTypeSelect(ProcessingModuleType.ocr)
+      },
+    ]
+  },
+  {
+    type: 'group',
+    label: 'Legacy',
+    items: [
+      {
+        type: 'item',
+        label: 'Filter file by name',
         onClick: handleModuleTypeSelect(ProcessingModuleType.filter)
       },
       {
         type: 'item',
-        label: 'Search image for text',
-        onClick: handleModuleTypeSelect(ProcessingModuleType.ocr)
+        label: 'Date prefix',
+        onClick: handleModuleTypeSelect(ProcessingModuleType.datePrefix)
+      },
+      {
+        type: 'item',
+        label: 'Iterate',
+        onClick: handleModuleTypeSelect(ProcessingModuleType.iterate)
       },
     ]
   }

--- a/h-util-ui/client/src/components/EditPipeline/PipelineOptions/OptionsPipelineSelect.vue
+++ b/h-util-ui/client/src/components/EditPipeline/PipelineOptions/OptionsPipelineSelect.vue
@@ -5,7 +5,7 @@ import store from '@utils/store';
 
 const props = defineProps<PipelineOptionsProps>();
 
-const pipelineOptions = computed(() => Object.values(store.state.pipelines).map(pipeline => ({
+const pipelineOptions = computed(() => Object.values(store.state.pipelines).filter(p => p.id !== store.state.selectedPipeline?.id).map(pipeline => ({
   label: pipeline.name,
   value: pipeline.id ?? '-'
 })))

--- a/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
+++ b/h-util-ui/client/src/components/editPipeline/EditPipeline.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onBeforeMount, watch } from 'vue';
+import { computed, ref, onBeforeMount, watch, provide } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
 import Palette from 'vue-material-design-icons/Palette.vue'
 import cloneDeep from 'lodash/cloneDeep';
@@ -22,6 +22,7 @@ const pipelineModules = ref<ProcessingModule[]>([
 const pipelineName = ref(`New pipeline ${new Date().toISOString()}`);
 const pipelineColor = ref<string>();
 const pipelineRanking = ref(DEFAULT_RANKING);
+const pipelineId = ref<string>();
 
 onBeforeMount(() => {
   const selected = store.state.selectedPipeline;
@@ -31,7 +32,10 @@ onBeforeMount(() => {
   pipelineName.value = selected.name;
   pipelineColor.value = selected.color;
   pipelineRanking.value = selected.manualRanking ?? DEFAULT_RANKING;
+  pipelineId.value = selected.id;
 })
+
+provide('pipelineModules', pipelineModules);
 
 const handleModuleUpdated = (newData: ProcessingModule | null, index: number) => {
   const targetedModule = pipelineModules.value[index];


### PR DESCRIPTION
Adds pipeline to provider for nested component to access. Additionally uses selected pipeline information to prevent pipelines directing to themselves.

Resolves #136 