### PR TITLE
[#150] Rework task monitor into sidebar

### DIFF
--- a/h-util-ui/client/src/App.vue
+++ b/h-util-ui/client/src/App.vue
@@ -7,7 +7,6 @@ import { VueComponent } from './utils/util.types'
 import { addErrorListeners, getIpcRenderer, loadUserData, sendMessageToMain } from './utils/helpers'
 import store from './utils/store'
 import { PageViews } from '@utils/types'
-import TaskList from './components/TaskList/TaskList.vue';
 import DrawerNav from './components/Nav/DrawerNav.vue'
 import Internals from './components/Internals/Internals.vue'
 import Directories from './components/Directories/Directories.vue'
@@ -65,17 +64,12 @@ onMounted(() => {
       <component :is="currentView" />
     </q-page-container>
   </q-layout>
-
-  <section class="task-list-container">
-    <TaskList />
-  </section>
 </template>
 
 <style scoped>
 .app-container {
   display: flex;
   flex-direction: column;
-  /* height: 90vh; */
 }
 
 .task-list-container {

--- a/h-util-ui/client/src/components/EditAqueduct/EditAqueduct.vue
+++ b/h-util-ui/client/src/components/EditAqueduct/EditAqueduct.vue
@@ -17,15 +17,6 @@ type Props = {
 const props = defineProps<Props>();
 const localAqueduct = ref(props.aqueduct);
 
-// TODO: Common directory display/editor card component
-const handleDirPrompt = async (index: number) => {
-  const folder = await getIpcRenderer()?.selectFolder();
-
-  if (!folder) return;
-
-  localAqueduct.value.directories[index] = folder;
-}
-
 const addDirectory = () => {
   localAqueduct.value.directories.push('');
 }

--- a/h-util-ui/client/src/components/Nav/DrawerNav.vue
+++ b/h-util-ui/client/src/components/Nav/DrawerNav.vue
@@ -6,6 +6,7 @@ import Waves from 'vue-material-design-icons/Waves.vue';
 import WrenchCog from 'vue-material-design-icons/WrenchCog.vue'
 import { PageViews } from '@utils/types';
 import { navigateTo } from '@utils/helpers';
+import NavTasks from './NavTasks.vue';
 
 const props = defineProps<{
   pathName: string;
@@ -30,6 +31,7 @@ const menuDisabled = computed(() => props.pathName === PageViews.Edit);
     @mouseleave="miniState = true" mini-to-overlay :width="200" :breakpoint="500" bordered>
     <q-scroll-area class="fit" :horizontal-thumb-style="{ opacity: '0' }">
       <q-list padding>
+
         <q-item>
           <q-item-section avatar>
             <FileCompare />
@@ -74,7 +76,9 @@ const menuDisabled = computed(() => props.pathName === PageViews.Edit);
             Tools & Internals
           </q-item-section>
         </q-item>
+
       </q-list>
+      <NavTasks />
     </q-scroll-area>
   </q-drawer>
 </template>
@@ -83,5 +87,9 @@ const menuDisabled = computed(() => props.pathName === PageViews.Edit);
 .main-title {
   font-weight: 600;
   user-select: none;
+}
+
+.main-menu {
+  flex-grow: 1;
 }
 </style>

--- a/h-util-ui/client/src/components/Nav/NavTaskItem.vue
+++ b/h-util-ui/client/src/components/Nav/NavTaskItem.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { SpawnedTask } from '@utils/types';
+import { computed } from 'vue';
+
+interface Props {
+  task: SpawnedTask & { pipelineName: string; }
+}
+
+const props = defineProps<Props>();
+
+const letter = computed(() => props.task.pipelineName[0] ?? '?')
+</script>
+
+<template>
+  <q-item>
+    <q-item-section avatar>
+      <q-circular-progress show-value :value="task.progress" size="24px" :thickness="0.5" track-color="grey-8">
+        <span>{{ letter }}</span>
+      </q-circular-progress>
+    </q-item-section>
+    <q-item-section>
+      <div class="task-info">
+        <div class="pipeline-name"> {{ task.pipelineName }}</div>
+        <div class="file-name">{{ task.name }}</div>
+      </div>
+    </q-item-section>
+  </q-item>
+</template>
+
+<style scoped>
+.task-info {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.pipeline-name {
+  max-width: 100%;
+  font-size: smaller;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-name {
+  font-size: x-small;
+  opacity: 0.7;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/h-util-ui/client/src/components/Nav/NavTasks.vue
+++ b/h-util-ui/client/src/components/Nav/NavTasks.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-/** @deprecated */
 import { computed, ref } from 'vue';
 import debounce from 'lodash/debounce';
 import { getIpcRenderer } from '@utils/helpers';
 import { SpawnedTask } from '@utils/types';
 import { MAX_TASKS } from '@utils/constants';
 import store from '@utils/store';
-import TaskListItem from './TaskListItem.vue';
+import NavTaskItem from './NavTaskItem.vue';
 
 const existingTasks = ref<Record<number, SpawnedTask>>({});
 const lowestId = ref<number>(0);
@@ -42,46 +41,20 @@ const sortedTaskList = computed(() => {
 </script>
 
 <template>
-  <div class="list-container">
-    <span v-if="sortedTaskList.length === 0" class="nothing">
-      No tasks at this moment
-    </span>
-    <div v-if="sortedTaskList.length > 0">
-      <div v-for="spawnedTask in sortedTaskList" :key="spawnedTask.id">
-        <TaskListItem :task="spawnedTask" />
-      </div>
-    </div>
-  </div>
-
+  <q-list class="task-area">
+    <NavTaskItem v-for="spawnedTask in sortedTaskList" :key="spawnedTask.id" :task="spawnedTask" />
+  </q-list>
 </template>
 
 <style scoped>
-.list-container {
-  /* background: var(--q-backingColor); */
-  padding: 1em;
-  font-size: x-small;
-  border-radius: 5px 5px 0 0;
-  width: 70%;
-  margin: auto;
-  border-top: 1px solid var(--q-lightColor);
-  position: relative;
-}
-
-.list-container::after {
-  content: "";
-  z-index: -1;
+.task-area {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: var(--q-backingColor);
-  opacity: 0.8;
-  mix-blend-mode: multiply;
-  backdrop-filter: blur(10px);
-}
+  bottom: 1em;
+  width: 100%;
 
-.nothing {
-  opacity: 0.5;
+  max-height: 100px;
+  overflow-y: auto;
+
+  border-top: 1px solid gray;
 }
 </style>

--- a/h-util-ui/client/src/global.css
+++ b/h-util-ui/client/src/global.css
@@ -58,3 +58,7 @@
     border: 1px solid #ccc;
   border-radius: 5px;
 }
+
+.q-circular-progress__svg {
+  color:var(--q-lightColor);
+}


### PR DESCRIPTION
Reworks task progress bars into the sidebar, to allow quick monitoring of what is working with option to rollover for details.

<img width="299" alt="Screenshot 2024-09-23 at 11 10 37 PM" src="https://github.com/user-attachments/assets/e76abb3b-da06-4880-910d-3b2408c0e95b">

Resolves #150 
Resolves #170 