### PR TITLE
[#189] Sqlite WASM migration - Part 2

### DIFF
--- a/h-util-ui/Electron/data/stats.db.ts
+++ b/h-util-ui/Electron/data/stats.db.ts
@@ -27,6 +27,7 @@ export const getStats = async (): Promise<PipelineStatsPayload[]> => {
 
 /**
  * This is a three-part
+ * @deprecated
  */
 export const addPipelineRunStat = async (
     pipelineUuid: string,

--- a/h-util-ui/Electron/main.ts
+++ b/h-util-ui/Electron/main.ts
@@ -16,10 +16,8 @@ import output from './util/output';
 import { handleErrorMessage, registerMainWindow } from './util/ipc';
 import { addListenersToIpc } from './ipcListeners';
 import { disconnectPrisma } from './data/database';
-import { initDbIfNeeded } from './data/sqlite';
 
 async function createWindow() {
-    // await initDbIfNeeded();
     addListenersToIpc(ipcMain);
 
     const { width, height } = screen.getPrimaryDisplay().workAreaSize;

--- a/h-util-ui/Electron/operations/aqueduct.ts
+++ b/h-util-ui/Electron/operations/aqueduct.ts
@@ -1,10 +1,10 @@
+import path from 'path';
 import { readdir } from 'fs/promises';
+import { promises } from '@common/common';
 import { AqueductLoadResponse, AqueductMessage } from '@shared/common.types';
 import { db } from '../data/database';
 import { pipelineDbToObject } from '../data/pipeline.db';
-import { promises } from '@common/common';
 import { runPipelineForFiles } from './handler';
-import path from 'path';
 
 export const handleAqueductMessage = async (message: AqueductMessage) => {
     switch (message.type) {

--- a/h-util-ui/Electron/operations/handler.ts
+++ b/h-util-ui/Electron/operations/handler.ts
@@ -12,7 +12,6 @@ import { addStat, updateTaskProgress } from '@util/ipc';
 import { CommonContext, FileOptions, FileWithMeta, ModuleHandler } from '@util/types';
 import { addEventLogForReport, fileListToFileOptions } from './handler.helpers';
 import { MODULE_MAP } from './modules/moduleMap';
-import { addPipelineRunStat } from '../data/stats.db';
 import branchingHandler from './modules/branching.handler';
 
 let globalTaskId = 0;
@@ -160,9 +159,6 @@ export const runPipelineForFiles = async (params: ProcessingRequest) => {
                     },
                 ],
             });
-            await addPipelineRunStat(pipeline.id, 'times_ran', 1);
-            await addPipelineRunStat(pipeline.id, 'time_taken', timeTaken);
-            await addPipelineRunStat(pipeline.id, 'files_processed', handled);
         },
     });
 };

--- a/h-util-ui/Electron/operations/handler.ts
+++ b/h-util-ui/Electron/operations/handler.ts
@@ -8,7 +8,7 @@ import {
     ProcessingRequest,
 } from '@shared/common.types';
 import { ProcessingError } from '@util/errors';
-import { updateTaskProgress } from '@util/ipc';
+import { addStat, updateTaskProgress } from '@util/ipc';
 import { CommonContext, FileOptions, FileWithMeta, ModuleHandler } from '@util/types';
 import { addEventLogForReport, fileListToFileOptions } from './handler.helpers';
 import { MODULE_MAP } from './modules/moduleMap';
@@ -144,6 +144,22 @@ export const runPipelineForFiles = async (params: ProcessingRequest) => {
 
     detachPromise({
         cb: async () => {
+            addStat({
+                pipelineUuid: pipeline.id,
+                stats: [
+                    {
+                        stat: 'times_ran',
+                    },
+                    {
+                        stat: 'time_taken',
+                        amount: timeTaken,
+                    },
+                    {
+                        stat: 'files_processed',
+                        amount: handled,
+                    },
+                ],
+            });
             await addPipelineRunStat(pipeline.id, 'times_ran', 1);
             await addPipelineRunStat(pipeline.id, 'time_taken', timeTaken);
             await addPipelineRunStat(pipeline.id, 'files_processed', handled);

--- a/h-util-ui/Electron/operations/modules/jpgCompress.handler.ts
+++ b/h-util-ui/Electron/operations/modules/jpgCompress.handler.ts
@@ -4,7 +4,6 @@ import { ProcessingError } from '@util/errors';
 import output from '@util/output';
 import { ModuleHandler } from '@util/types';
 import { addEventLogForReport } from '../handler.helpers';
-import { addPipelineRunStat } from '../../data/stats.db';
 import { addStat } from '@util/ipc';
 
 const jpgCompressHandler: ModuleHandler = {
@@ -27,7 +26,6 @@ const jpgCompressHandler: ModuleHandler = {
         const reduced = sizeBefore - sizeAfter;
 
         if (opts.context?.pipelineId) {
-            void addPipelineRunStat(opts.context.pipelineId, 'bytes_compressed', reduced);
             addStat({
                 pipelineUuid: opts.context.pipelineId,
                 stats: [

--- a/h-util-ui/Electron/operations/modules/jpgCompress.handler.ts
+++ b/h-util-ui/Electron/operations/modules/jpgCompress.handler.ts
@@ -5,6 +5,7 @@ import output from '@util/output';
 import { ModuleHandler } from '@util/types';
 import { addEventLogForReport } from '../handler.helpers';
 import { addPipelineRunStat } from '../../data/stats.db';
+import { addStat } from '@util/ipc';
 
 const jpgCompressHandler: ModuleHandler = {
     handler: async (fileWithMeta, opts) => {
@@ -25,7 +26,18 @@ const jpgCompressHandler: ModuleHandler = {
         const sizeAfter = await getFileSize(filePath, 'number');
         const reduced = sizeBefore - sizeAfter;
 
-        if (opts.context?.pipelineId) void addPipelineRunStat(opts.context.pipelineId, 'bytes_compressed', reduced);
+        if (opts.context?.pipelineId) {
+            void addPipelineRunStat(opts.context.pipelineId, 'bytes_compressed', reduced);
+            addStat({
+                pipelineUuid: opts.context.pipelineId,
+                stats: [
+                    {
+                        stat: 'bytes_compressed',
+                        amount: reduced,
+                    },
+                ],
+            });
+        }
 
         output.log(`${fileName} reduced by ${reduced}b`);
 

--- a/h-util-ui/Electron/operations/modules/movCompress.handler.ts
+++ b/h-util-ui/Electron/operations/modules/movCompress.handler.ts
@@ -12,6 +12,7 @@ import output from '@util/output';
 import { ModuleHandler } from '@util/types';
 import { addEventLogForReport } from '../handler.helpers';
 import { addPipelineRunStat } from '../../data/stats.db';
+import { addStat } from '@util/ipc';
 
 const movCompressHandler: ModuleHandler = {
     handler: async (fileWithMeta, opts) => {
@@ -31,7 +32,18 @@ const movCompressHandler: ModuleHandler = {
         const sizeAfter = await getFileSize(filePath, 'number');
         const reduced = sizeBefore - sizeAfter;
 
-        if (opts.context?.pipelineId) void addPipelineRunStat(opts.context.pipelineId, 'bytes_compressed', reduced);
+        if (opts.context?.pipelineId) {
+            void addPipelineRunStat(opts.context.pipelineId, 'bytes_compressed', reduced);
+            addStat({
+                pipelineUuid: opts.context.pipelineId,
+                stats: [
+                    {
+                        stat: 'bytes_compressed',
+                        amount: reduced,
+                    },
+                ],
+            });
+        }
 
         if (reduced < 0) output.out(`${fileName} bloated by ${reduced}b`);
         else output.log(`${fileName} reduced by ${reduced}b`);

--- a/h-util-ui/Electron/operations/modules/movCompress.handler.ts
+++ b/h-util-ui/Electron/operations/modules/movCompress.handler.ts
@@ -11,7 +11,6 @@ import { ProcessingError } from '@util/errors';
 import output from '@util/output';
 import { ModuleHandler } from '@util/types';
 import { addEventLogForReport } from '../handler.helpers';
-import { addPipelineRunStat } from '../../data/stats.db';
 import { addStat } from '@util/ipc';
 
 const movCompressHandler: ModuleHandler = {
@@ -33,7 +32,6 @@ const movCompressHandler: ModuleHandler = {
         const reduced = sizeBefore - sizeAfter;
 
         if (opts.context?.pipelineId) {
-            void addPipelineRunStat(opts.context.pipelineId, 'bytes_compressed', reduced);
             addStat({
                 pipelineUuid: opts.context.pipelineId,
                 stats: [

--- a/h-util-ui/Electron/operations/modules/ocr.handler.ts
+++ b/h-util-ui/Electron/operations/modules/ocr.handler.ts
@@ -1,7 +1,6 @@
 import { checkSupportedExt, searchForTextInImage, splitFileNameFromPath } from '@common/fileops';
 import { ModuleHandler } from '@util/types';
 import { addEventLogForReport } from '../handler.helpers';
-import { addPipelineRunStat } from '../../data/stats.db';
 import { addStat } from '@util/ipc';
 
 const ocrHandler: ModuleHandler = {
@@ -18,7 +17,6 @@ const ocrHandler: ModuleHandler = {
         const hasMatches = await searchForTextInImage(fileWithMeta.filePath, matches);
 
         if (opts.context?.pipelineId) {
-            void addPipelineRunStat(opts.context.pipelineId, 'words_parsed', matches.length);
             addStat({
                 pipelineUuid: opts.context.pipelineId,
                 stats: [

--- a/h-util-ui/Electron/operations/modules/ocr.handler.ts
+++ b/h-util-ui/Electron/operations/modules/ocr.handler.ts
@@ -2,6 +2,7 @@ import { checkSupportedExt, searchForTextInImage, splitFileNameFromPath } from '
 import { ModuleHandler } from '@util/types';
 import { addEventLogForReport } from '../handler.helpers';
 import { addPipelineRunStat } from '../../data/stats.db';
+import { addStat } from '@util/ipc';
 
 const ocrHandler: ModuleHandler = {
     handler: async (fileWithMeta, opts) => {
@@ -16,7 +17,18 @@ const ocrHandler: ModuleHandler = {
 
         const hasMatches = await searchForTextInImage(fileWithMeta.filePath, matches);
 
-        if (opts.context?.pipelineId) void addPipelineRunStat(opts.context.pipelineId, 'words_parsed', matches.length);
+        if (opts.context?.pipelineId) {
+            void addPipelineRunStat(opts.context.pipelineId, 'words_parsed', matches.length);
+            addStat({
+                pipelineUuid: opts.context.pipelineId,
+                stats: [
+                    {
+                        stat: 'words_parsed',
+                        amount: matches.length,
+                    },
+                ],
+            });
+        }
 
         const { fileName } = splitFileNameFromPath(fileWithMeta.filePath);
 

--- a/h-util-ui/Electron/operations/modules/ruleFilter.handler.ts
+++ b/h-util-ui/Electron/operations/modules/ruleFilter.handler.ts
@@ -2,7 +2,6 @@ import { splitFileNameFromPath } from '@common/fileops';
 import { ModuleHandler } from '@util/types';
 import { addEventLogForReport, evaluateRulesForFile } from '../handler.helpers';
 import { ExtraData } from '@shared/common.constants';
-import { addPipelineRunStat } from '../../../Electron/data/stats.db';
 import { addStat } from '@util/ipc';
 
 const ruleFilterHandler: ModuleHandler = {
@@ -17,7 +16,6 @@ const ruleFilterHandler: ModuleHandler = {
             onDataDict: (dataDict, ocrOptions) => {
                 if (dataDict[ExtraData.ocr])
                     if (ocrOptions?.length && opts.context?.pipelineId) {
-                        void addPipelineRunStat(opts.context.pipelineId, 'words_parsed', ocrOptions.length);
                         addStat({
                             pipelineUuid: opts.context.pipelineId,
                             stats: [

--- a/h-util-ui/Electron/operations/modules/ruleFilter.handler.ts
+++ b/h-util-ui/Electron/operations/modules/ruleFilter.handler.ts
@@ -3,6 +3,7 @@ import { ModuleHandler } from '@util/types';
 import { addEventLogForReport, evaluateRulesForFile } from '../handler.helpers';
 import { ExtraData } from '@shared/common.constants';
 import { addPipelineRunStat } from '../../../Electron/data/stats.db';
+import { addStat } from '@util/ipc';
 
 const ruleFilterHandler: ModuleHandler = {
     handler: async (fileWithMeta, opts) => {
@@ -15,8 +16,18 @@ const ruleFilterHandler: ModuleHandler = {
         const excluded = await evaluateRulesForFile(fileWithMeta.filePath, rules, {
             onDataDict: (dataDict, ocrOptions) => {
                 if (dataDict[ExtraData.ocr])
-                    if (ocrOptions?.length && opts.context?.pipelineId)
+                    if (ocrOptions?.length && opts.context?.pipelineId) {
                         void addPipelineRunStat(opts.context.pipelineId, 'words_parsed', ocrOptions.length);
+                        addStat({
+                            pipelineUuid: opts.context.pipelineId,
+                            stats: [
+                                {
+                                    stat: 'words_parsed',
+                                    amount: ocrOptions.length,
+                                },
+                            ],
+                        });
+                    }
             },
         });
 

--- a/h-util-ui/Electron/preload.ts
+++ b/h-util-ui/Electron/preload.ts
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld('electronIpc', {
         ipcRenderer.on('main-message', (_e, payload) => {
             cb(payload.message);
         }),
+    onStatUpdate: (cb: (statPayload: object) => void) => ipcRenderer.on('update-stat', (_e, payload) => cb(payload)),
     onTaskProgress: (cb: (taskInfo: string) => void) => ipcRenderer.on('task-progress', (_e, payload) => cb(payload)),
     loadData: () => ipcRenderer.invoke('load-data'),
     saveFile: (content: string) => ipcRenderer.invoke('save-file', content),

--- a/h-util-ui/Electron/util/ipc.ts
+++ b/h-util-ui/Electron/util/ipc.ts
@@ -2,7 +2,7 @@ import { BrowserWindow } from 'electron';
 
 import output from './output';
 import { IpcMessageType } from '../../common/common.constants';
-import { SpawnedTask } from '@shared/common.types';
+import { SpawnedTask, UpdateStatPayload } from '@shared/common.types';
 import logger from '@util/logger';
 
 let mainWindow: BrowserWindow | null = null;
@@ -39,4 +39,13 @@ export const updateTaskProgress = (data: SpawnedTask) => {
 
 export const handleErrorMessage = (message: string, stack?: string) => {
     logger.error(`[err] Error: ${message}`, stack);
+};
+
+export const addStat = (payload: UpdateStatPayload) => {
+    if (!mainWindow) {
+        output.error('Main window not initialized');
+        return;
+    }
+
+    mainWindow.webContents.send(IpcMessageType.updateStat, payload);
 };

--- a/h-util-ui/client/src/App.vue
+++ b/h-util-ui/client/src/App.vue
@@ -49,7 +49,7 @@ onMounted(() => {
   })
 
   initializeSQLite().then(() => {
-    models.pipeline.selectAll();
+    console.log(models.pipeline.selectAll());
   });
 
   loadUserData().then(data => {

--- a/h-util-ui/client/src/App.vue
+++ b/h-util-ui/client/src/App.vue
@@ -53,19 +53,13 @@ onMounted(() => {
 
   getIpcRenderer().onStatUpdate(({ pipelineUuid, stats }: UpdateStatPayload) =>
     stats.forEach(({ stat, amount }) => models.stats.addRunStat(pipelineUuid, stat, amount))
-
   );
 
   initializeSQLite().then(() => {
     loading.value = false;
-    console.log(models.pipeline.selectAll());
+    const pipelines = models.pipeline.selectAll();
+    store.setAllPipelines(pipelines);
   });
-
-  loadUserData().then(data => {
-    if (!data) return;
-
-    store.setAllPipelines(data.pipelines);
-  })
 
   addErrorListeners();
 })

--- a/h-util-ui/client/src/components/Directories/AqueductGallery.vue
+++ b/h-util-ui/client/src/components/Directories/AqueductGallery.vue
@@ -28,12 +28,7 @@ const handleRun = (id: string) => {
 }
 
 const handleDelete = async (aqueDuctId: string) => {
-  await getIpcRenderer().invoke<AqueductMessage>(IpcMessageType.aqueducts, {
-    type: 'delete',
-    aqueDuctId
-  })
-
-  console.log('get', models.aqueducts.remove(aqueDuctId));
+  models.aqueducts.remove(aqueDuctId);
 
   emit('update');
 }

--- a/h-util-ui/client/src/components/Directories/AqueductGallery.vue
+++ b/h-util-ui/client/src/components/Directories/AqueductGallery.vue
@@ -6,6 +6,7 @@ import PageLayout from 'src/layout/PageLayout.vue';
 import { getIpcRenderer } from '@utils/helpers';
 import { IpcMessageType } from '@shared/common.constants';
 import AqueductItem from './AqueductItem.vue';
+import { models } from 'src/data/models';
 
 type Props = {
   aqueducts: Aqueduct[] | null;
@@ -31,6 +32,8 @@ const handleDelete = async (aqueDuctId: string) => {
     type: 'delete',
     aqueDuctId
   })
+
+  console.log('get', models.aqueducts.remove(aqueDuctId));
 
   emit('update');
 }

--- a/h-util-ui/client/src/components/Directories/AqueductItem.vue
+++ b/h-util-ui/client/src/components/Directories/AqueductItem.vue
@@ -28,7 +28,7 @@ const handleDelete = () => emit('delete');
 
 const pipelineName = computed(() => {
   const pipeline = store.state.pipelines[props.aqueduct.pipelineId];
-  return pipeline.name ?? 'Unknown pipeline';
+  return pipeline?.name ?? 'Unknown pipeline';
 })
 </script>
 

--- a/h-util-ui/client/src/components/Directories/Directories.vue
+++ b/h-util-ui/client/src/components/Directories/Directories.vue
@@ -7,12 +7,15 @@ import { getDefaultAqueduct } from '@utils/models.helpers';
 import store from '@utils/store';
 import EditAqueduct from '../EditAqueduct/EditAqueduct.vue';
 import AqueductGallery from './AqueductGallery.vue';
+import { models } from 'src/data/models';
 
 const stateStore = ref(store.state);
 const selectedAqueduct = ref<Aqueduct | null>(null);
 
 const fetchAqueducts = async () => {
   const data = await getIpcRenderer().invoke<AqueductMessage, AqueductLoadResponse>(IpcMessageType.aqueducts, { type: 'load' });
+
+  console.log('select', models.aqueducts.selectAll());
 
   if (data) store.setAqueducts(data.data);
 }

--- a/h-util-ui/client/src/components/Directories/Directories.vue
+++ b/h-util-ui/client/src/components/Directories/Directories.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import { IpcMessageType } from '@shared/common.constants';
-import { Aqueduct, AqueductLoadResponse, AqueductMessage } from '@shared/common.types';
-import { getIpcRenderer } from '@utils/helpers';
+import { Aqueduct } from '@shared/common.types';
 import { getDefaultAqueduct } from '@utils/models.helpers';
 import store from '@utils/store';
 import EditAqueduct from '../EditAqueduct/EditAqueduct.vue';
@@ -13,11 +11,9 @@ const stateStore = ref(store.state);
 const selectedAqueduct = ref<Aqueduct | null>(null);
 
 const fetchAqueducts = async () => {
-  const data = await getIpcRenderer().invoke<AqueductMessage, AqueductLoadResponse>(IpcMessageType.aqueducts, { type: 'load' });
+  const data = models.aqueducts.selectAll();
 
-  console.log('select', models.aqueducts.selectAll());
-
-  if (data) store.setAqueducts(data.data);
+  if (data) store.setAqueducts(data);
 }
 
 onMounted(async () => {

--- a/h-util-ui/client/src/components/EditAqueduct/EditAqueduct.vue
+++ b/h-util-ui/client/src/components/EditAqueduct/EditAqueduct.vue
@@ -8,6 +8,7 @@ import { getIpcRenderer, removeVueRefs } from '@utils/helpers';
 import { IpcMessageType } from '@shared/common.constants';
 import PipelineSelector from '../common/PipelineSelector.vue';
 import DirectoryPicker from '../common/DirectoryPicker.vue';
+import { models } from 'src/data/models';
 
 type Props = {
   aqueduct: Aqueduct;
@@ -29,6 +30,8 @@ const removeDirectory = (index: number) => {
 
 const handleSave = async () => {
   await getIpcRenderer().invoke<AqueductMessage>(IpcMessageType.aqueducts, { type: 'save', data: removeVueRefs(localAqueduct.value) })
+
+  models.aqueducts.upsert(removeVueRefs(localAqueduct.value));
 
   props.returnHome();
   emit('update');

--- a/h-util-ui/client/src/components/EditAqueduct/EditAqueduct.vue
+++ b/h-util-ui/client/src/components/EditAqueduct/EditAqueduct.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { Aqueduct, AqueductMessage } from '@shared/common.types';
+import { Aqueduct } from '@shared/common.types';
 import Delete from 'vue-material-design-icons/Delete.vue'
 import PageLayout from 'src/layout/PageLayout.vue';
 
-import { getIpcRenderer, removeVueRefs } from '@utils/helpers';
-import { IpcMessageType } from '@shared/common.constants';
+import { removeVueRefs } from '@utils/helpers';
 import PipelineSelector from '../common/PipelineSelector.vue';
 import DirectoryPicker from '../common/DirectoryPicker.vue';
 import { models } from 'src/data/models';
@@ -29,8 +28,6 @@ const removeDirectory = (index: number) => {
 }
 
 const handleSave = async () => {
-  await getIpcRenderer().invoke<AqueductMessage>(IpcMessageType.aqueducts, { type: 'save', data: removeVueRefs(localAqueduct.value) })
-
   models.aqueducts.upsert(removeVueRefs(localAqueduct.value));
 
   props.returnHome();

--- a/h-util-ui/client/src/components/about/AboutModal.vue
+++ b/h-util-ui/client/src/components/about/AboutModal.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue';
 import { PipelineStatsPayload } from '@shared/common.types';
 import { loadStats, } from '@utils/helpers';
 import StatsDisplay from './StatsDisplay.vue';
+import { models } from 'src/data/models';
 
 enum Tabs {
   stats = 'stat',
@@ -19,6 +20,7 @@ defineProps<{
 }>();
 
 const getStats = () => {
+  console.log('get stats', models.stats.selectAll());
   loadStats().then(data => {
     stats.value = data;
   })

--- a/h-util-ui/client/src/components/about/AboutModal.vue
+++ b/h-util-ui/client/src/components/about/AboutModal.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { PipelineStatsPayload } from '@shared/common.types';
-import { loadStats, } from '@utils/helpers';
 import StatsDisplay from './StatsDisplay.vue';
 import { models } from 'src/data/models';
 
@@ -20,10 +19,8 @@ defineProps<{
 }>();
 
 const getStats = () => {
-  console.log('get stats', models.stats.selectAll());
-  loadStats().then(data => {
-    stats.value = data;
-  })
+  const data = models.stats.selectAll();
+  stats.value = data;
 }
 
 watch(about, (newValue, oldValue) => {

--- a/h-util-ui/client/src/data/models.ts
+++ b/h-util-ui/client/src/data/models.ts
@@ -1,4 +1,4 @@
-import { Aqueduct, Pipeline, PipelineStatsPayload } from '@shared/common.types';
+import { Aqueduct, Pipeline, PipelineStats, PipelineStatsPayload } from '@shared/common.types';
 import { queryDatabase } from './sqlite';
 
 export const pipeline = {
@@ -104,18 +104,6 @@ export const pipeline = {
     },
 };
 
-type PipelineStats = {
-    /** Refers to pipeline stats' id */
-    id: number;
-    /** fkey */
-    pipeline_id: number;
-    times_ran: number;
-    time_taken: number;
-    bytes_compressed: number;
-    words_parsed: number;
-    files_processed: number;
-};
-
 const stats = {
     create: (pipelineId: number) => {
         const createPipelineStatsQuery = `--sql
@@ -194,7 +182,7 @@ const aqueducts = {
             a.name,
             a.description,
             a.directories
-          FROM Aqueducts a
+          FROM Aqueduct a
           JOIN Pipeline p ON a.pipeline_id = p.id;
         `;
 
@@ -220,9 +208,9 @@ const aqueducts = {
           ), ?, ?, ?)
           ON CONFLICT(uuid) DO UPDATE SET
             name = excluded.name,
-            color = excluded.color,
-            manual_ranking = excluded.manual_ranking,
-            modified = CURRENT_TIMESTAMP;
+            description = excluded.description,
+            directories = excluded.directories,
+            pipeline_id = excluded.pipeline_id;
         `;
 
         queryDatabase.run(aqueductQuery, [

--- a/h-util-ui/client/src/data/models.ts
+++ b/h-util-ui/client/src/data/models.ts
@@ -1,5 +1,6 @@
 import { Aqueduct, Pipeline, PipelineStats, PipelineStatsPayload } from '@shared/common.types';
 import { queryDatabase } from './sqlite';
+import { DEFAULT_RANKING } from '@utils/constants';
 
 export const pipeline = {
     upsert: (pipeline: Pipeline) => {
@@ -12,7 +13,12 @@ export const pipeline = {
             manual_ranking = excluded.manual_ranking,
             modified = CURRENT_TIMESTAMP;
         `;
-        queryDatabase.run(pipelineQuery, [pipeline.id, pipeline.name, pipeline.color, pipeline.manualRanking]);
+        queryDatabase.run(pipelineQuery, [
+            pipeline.id,
+            pipeline.name,
+            pipeline.color,
+            pipeline.manualRanking ?? DEFAULT_RANKING,
+        ]);
 
         const pipelineIdQuery = `SELECT id FROM Pipeline WHERE uuid = ?`;
         const pipelineIdResult = queryDatabase.select<string>(pipelineIdQuery, [pipeline.id]);

--- a/h-util-ui/client/src/data/sqlite.ts
+++ b/h-util-ui/client/src/data/sqlite.ts
@@ -15,10 +15,12 @@ const error = console.error;
 let database: Database | null = null;
 
 const start = async (sqlite3: Sqlite3Static, _dbPath: string) => {
-    log('Running SQLite3 version', sqlite3.version.libVersion);
+    // todo: migrate to OPFS
     const db = new sqlite3.oo1.JsStorageDb('local');
     database = db;
+
     await initDbIfNeeded();
+    log('Running SQLite3 version', sqlite3.version.libVersion);
 };
 
 const noDatabaseError = () => {

--- a/h-util-ui/client/src/utils/global.d.ts
+++ b/h-util-ui/client/src/utils/global.d.ts
@@ -18,6 +18,7 @@ type IpcRendererExposed = {
     on: <T>(channel: string, cb: (event: unknown, message: T) => void) => void;
     onMainMessage: (cb: (msg: string) => void) => void;
     onTaskProgress: (cb: (task: string) => void) => void;
+    onStatUpdate: <T>(cb: (payload: T) => void) => void;
     loadData: <T>() => Promise<T>;
     saveFile: (content: string) => Promise<void>;
     saveData: (data: string[]) => Promise<void>;

--- a/h-util-ui/client/src/utils/helpers.ts
+++ b/h-util-ui/client/src/utils/helpers.ts
@@ -39,6 +39,9 @@ export const sendMessageToMain = (message: string) => {
     ipcRenderer.send(IpcMessageType.clientMessage, [message]);
 };
 
+/**
+ * @deprecated
+ */
 export const loadUserData = async () => {
     const ipcRenderer = getIpcRenderer();
 
@@ -47,6 +50,9 @@ export const loadUserData = async () => {
     return await ipcRenderer?.invoke<null, Storage>(IpcMessageType.loadData);
 };
 
+/**
+ * @deprecated
+ */
 export const loadStats = async () => {
     const ipcRenderer = getIpcRenderer();
 
@@ -59,10 +65,6 @@ export const loadStats = async () => {
 export const removeVueRefs = <T>(source: T): T => JSON.parse(JSON.stringify(source));
 
 export const saveUserData = (pipelines: VueStore['pipelines']) => {
-    const ipcRenderer = getIpcRenderer();
-
-    ipcRenderer?.invoke(IpcMessageType.saveData, { pipelines: removeVueRefs(pipelines) });
-
     // todo: no need to "bulk" upsert
     Object.values(removeVueRefs(pipelines)).forEach((pipeline) => {
         models.pipeline.upsert(pipeline);

--- a/h-util-ui/client/src/utils/store.ts
+++ b/h-util-ui/client/src/utils/store.ts
@@ -31,6 +31,7 @@ const state = reactive<VueStore>({
     },
 });
 
+// TODO: save individual pipeline instead of all
 const onPipelinesUpdated = () => {
     saveUserData({ ...state.pipelines });
 };

--- a/h-util-ui/common/common.constants.ts
+++ b/h-util-ui/common/common.constants.ts
@@ -28,6 +28,8 @@ export enum IpcMessageType {
     /** An "aqueduct" operation */
     aqueducts = 'aqueducts',
     getDbPath = 'get-db-path',
+    /** Let main request renderer to update stats */
+    updateStat = 'update-stat',
 }
 
 export enum RenameTemplates {

--- a/h-util-ui/common/common.types.ts
+++ b/h-util-ui/common/common.types.ts
@@ -142,6 +142,18 @@ export type RenameTestRequest = {
     filePaths: string[];
 };
 
+export type PipelineStats = {
+    /** Refers to pipeline stats' id */
+    id: number;
+    /** fkey */
+    pipeline_id: number;
+    times_ran: number;
+    time_taken: number;
+    bytes_compressed: number;
+    words_parsed: number;
+    files_processed: number;
+};
+
 export type Aqueduct = {
     id: string;
     pipelineId: string;
@@ -166,4 +178,10 @@ export type AqueductMessage =
 
 export type AqueductLoadResponse = {
     data: Aqueduct[];
+};
+
+export type UpdateStatPayload = {
+    pipelineUuid: string;
+    stat: keyof PipelineStats;
+    amount?: number;
 };

--- a/h-util-ui/common/common.types.ts
+++ b/h-util-ui/common/common.types.ts
@@ -182,6 +182,8 @@ export type AqueductLoadResponse = {
 
 export type UpdateStatPayload = {
     pipelineUuid: string;
-    stat: keyof PipelineStats;
-    amount?: number;
+    stats: {
+        stat: keyof PipelineStats;
+        amount?: number;
+    }[];
 };


### PR DESCRIPTION
Completes migration from Prisma to SQlite-wasm.

This was necessary as Prisma is poorly optimized and adds a lot of complexity for the building process, let alone adding a lot of size to an already large Electron project.

It currently uses kvvms, which is not optimal, as the other oo1 method had difficulty linking. This is not optimal as it is under the constraints that `localStorage` imposes, and should be eventually moved over to OPFS.

Resolves #189