### PR TITLE
[#230] Implement smart-ish renaming

### DIFF
--- a/h-util-ui/Electron/operations/modules/nameTag.helpers.ts
+++ b/h-util-ui/Electron/operations/modules/nameTag.helpers.ts
@@ -1,0 +1,17 @@
+const makeFileSafe = (input: string) => input.replace(/[^a-zA-Z0-9 _.\-()]/g, '_');
+/**
+ * Source: GPT ;)
+ * @param filename Title from filename
+ * @param metadataTitle
+ * @returns
+ */
+export const fileNameSafeTitleReplace = (filename: string, metadataTitle: string): string => {
+    const fileSafeFilename = makeFileSafe(filename);
+    const fileSafeTitle = makeFileSafe(metadataTitle);
+
+    if (fileSafeTitle === metadataTitle) return filename; // No change needed
+
+    if (!fileSafeFilename.includes(fileSafeTitle)) return filename; // No match found
+
+    return filename.replace(fileSafeTitle, metadataTitle);
+};

--- a/h-util-ui/Electron/operations/nameTag.helpers.spec.ts
+++ b/h-util-ui/Electron/operations/nameTag.helpers.spec.ts
@@ -1,0 +1,40 @@
+import { fileNameSafeTitleReplace } from './modules/nameTag.helpers';
+
+// By GPT ;)
+describe('fileNameSafeTitleReplace', () => {
+    it('returns filename if fileSafeTitle equals filename', () => {
+        expect(fileNameSafeTitleReplace('My_Title', 'My_Title')).toBe('My_Title');
+    });
+
+    it('returns filename if fileSafeTitle is not in filename', () => {
+        expect(fileNameSafeTitleReplace('SomeFileName', 'AnotherTitle')).toBe('SomeFileName');
+    });
+
+    it('replaces fileSafeTitle in filename with metadataTitle', () => {
+        expect(fileNameSafeTitleReplace('My_Title_2024', 'My Title')).toBe('My Title_2024');
+    });
+
+    it('replaces all occurrences of fileSafeTitle in filename', () => {
+        expect(fileNameSafeTitleReplace('My_Title_and_My_Title', 'My Title')).toBe('My Title_and_My Title');
+    });
+
+    it('handles special characters in metadataTitle', () => {
+        expect(fileNameSafeTitleReplace('My_Title_2024', 'My/Title')).toBe('My/Title_2024');
+    });
+
+    it('returns filename unchanged if metadataTitle is empty', () => {
+        expect(fileNameSafeTitleReplace('SomeFile', '')).toBe('SomeFile');
+    });
+
+    it('returns filename unchanged if filename is empty', () => {
+        expect(fileNameSafeTitleReplace('', 'Some Title')).toBe('');
+    });
+
+    it('handles both filename and metadataTitle with special characters', () => {
+        expect(fileNameSafeTitleReplace('My_Title_#1', 'My@Title')).toBe('My@Title_#1');
+    });
+
+    it('does not replace partial matches', () => {
+        expect(fileNameSafeTitleReplace('My_Title_Extra', 'My Tit')).toBe('My_Title_Extra');
+    });
+});


### PR DESCRIPTION
Adds smart-ish renaming where if the source title is sanitized for filenames, we inject the original metadata title instead.

<img width="699" alt="Screenshot 2025-06-04 at 9 16 34 PM" src="https://github.com/user-attachments/assets/884fd293-0528-4d65-913a-a3990e62e0eb" />

Resolves #230